### PR TITLE
Fixes links in resume review training page. [Fixes #58]

### DIFF
--- a/pages/phases/reviewing-resumes/training.md
+++ b/pages/phases/reviewing-resumes/training.md
@@ -17,14 +17,33 @@ intro: Before providing SMEs with their resume review assignments, conduct a two
 
 Send calendar invites to all SMEs who will review resumes for your hiring action, including those who will provide tiebreaker reviews.
 
+
 To prepare for your training:
-- Update the `[resume review training presentation template](toolkit-link)` with your agency-specific information, including the final competencies and proficiencies from your job analysis workshop.
-- Gather sample resumes from the `[USAJOBS Agency Talent Portal](link?)`. To request an account, write to <a href="mailto:recruiter-help@usajobs.gov">recruiter-help@usajobs.gov</a>. You'll need around five resumes total from both private sector and current federal employees in the role you're hiring for.  
-- Prepare your handouts:
-  - [ ] [Training agenda](../toolkit/resume-review-training-agenda/)
-  - [ ] Five sample resumes per SME
-  - [ ] Required competencies and proficiency levels from job analysis
-  - [ ] `[Resume review instructions for SMEs](toolkit-link)`
+<ul>
+  <li>
+    Update the <a href="{{ site.baseurl }}/toolkit/reviewing-resumes/sme-training-resume-review.pptx">resume review training presentation template</a> with your agency-specific information, including the final competencies and proficiencies from your job analysis workshop.
+  </li>
+  <li>
+    Gather sample resumes from the <a href="https://agencyportal.usajobs.gov/">USAJOBS Agency Talent Portal</a>. To request an account, write to <a href="mailto:recruiter-help@usajobs.gov">recruiter-help@usajobs.gov</a>. You'll need around five resumes total from both private sector and current federal employees in the role you're hiring for.  
+  </li>
+  <li>
+    Prepare your handouts:
+    <ul>
+      <li>
+        <input type="checkbox" name="item1">&nbsp;<a href="{{ site.baseurl }}/toolkit/reviewing-resumes/resume-review-training-agenda/">Training agenda</a></li>
+      <li>
+        <input type="checkbox" name="item2">&nbsp; Five sample resumes per SME
+      </li>
+      <li>
+        <input type="checkbox" name="item3">&nbsp; Required competencies and proficiency levels from job analysis
+      </li>
+      <li>
+        <input type="checkbox" name="item4">&nbsp; Resume review instructions for SMEs (forthcoming)
+      </li>
+    </ul>
+  </li>
+</ul>
+
 
 ## Providing SMEs With Assignments
 


### PR DESCRIPTION
We don't have resume review instructions written up for SMEs. Probably because we don't know if our tool will be done in time. But I'll file a separate issue for that little snafu. This at least fixes the other "links" on this page that Sheri left for me to fix.