### PR TITLE
Revises the issuing a certificate toolkit items to share the same key…

### DIFF
--- a/_includes/_results-key.md
+++ b/_includes/_results-key.md
@@ -1,0 +1,9 @@
+
+| Interview 1 Assessment Rating | Interview 2 Assessment Rating | Overall Outcome | Final Score| Category |
+| :--- | :--- | :--- | :--- |
+| 1 | 1 | Applicant Meets Qualifications | 70 | Qualified |
+| 1 | 2 | Applicant Meets Qualifications | 85 | Well Qualified |
+| 2 | 1 | Applicant Meets Qualifications | 85 | Well Qualified |
+| 2 | 2 | Applicant Meets Qualifications | 100 | Best Qualified |
+| 1 or 2 | 0 | Applicant Does Not Meet Qualifications |
+| 0 | N/A | Does Not Move Forward to Interview Two |

--- a/pages/phases/certificate.md
+++ b/pages/phases/certificate.md
@@ -35,7 +35,7 @@ During resume review and interview assessments, applicants can be removed from c
 
 ### Time in Grade Verification
 
-In addition, at this stage you should verify the Time in Grade requirements for those applicants who will be on the certificate. However, there is no need to double check an applicant that a SME has determined does not meet the time in grade requirement. 
+In addition, at this stage you may verify the Time in Grade requirements for those applicants who will be on the certificate.
 
 ## Post-Certificate Interviews
 

--- a/pages/phases/certificate.md
+++ b/pages/phases/certificate.md
@@ -33,6 +33,10 @@ roles: [hr, hiring-mgr]
 
 During resume review and interview assessments, applicants can be removed from consideration if SMEs determine they're not qualified based on the required competencies and proficiencies. As HR, you should apply veterans' preference only to applicants who achieve an overall passing score, then issue the certificate of applicants in the "Best Qualified" category to the hiring manager.
 
+### Time in Grade Verification
+
+In addition, at this stage you should verify the Time in Grade requirements for those applicants who will be on the certificate. However, there is no need to double check an applicant that a SME has determined does not meet the time in grade requirement. 
+
 ## Post-Certificate Interviews
 
 Hiring managers may conduct additional interviews with applicants from the certificate, or choose instead to rely on the interview transcript notes to determine whether they'll make selections from the certificate.

--- a/toolkit/certificate/preference-adjudication-rating-guide.md
+++ b/toolkit/certificate/preference-adjudication-rating-guide.md
@@ -12,8 +12,4 @@ For applicants who proceed through both assessment interviews, transmute the int
 
 **NOTE:** Applicants who do not receive a combination of 1s and 2s are not placed in a category as they did not achieve an overall passing score.
 
-| Interview Ratings | Resulting Points | Category |
-|:---:|:---:|:---:|
-| Two 1s | 70 | Qualified |
-| One 1, One 2 | 85 (average of 70 and 100) | Well Qualified |
-| Two 2s | 100 | Best Qualified |
+{% include _results-key.md %}

--- a/toolkit/certificate/transmuting-ratings-into-scores.md
+++ b/toolkit/certificate/transmuting-ratings-into-scores.md
@@ -15,3 +15,5 @@ For applicants who proceed through both interviews (breadth and depth), HR shoul
 - Any applicant with two 2s should get 100 points (category: best qualified).
 
 Applicants who do not receive a combination of 1s and 2s would not be placed in a category as they did not achieve an overall passing score.
+
+{% include _results-key.md %}

--- a/toolkit/phone-assessment-interviews/interview-results-key.md
+++ b/toolkit/phone-assessment-interviews/interview-results-key.md
@@ -8,11 +8,4 @@ title: Interview Results Key
 description: Use this key to understand how to provide a final interview outcome assessment.
 ---
 
-| Interview 1 Assessment Rating | Interview 2 Assessment Rating | Overall Outcome | Final Score|
-| :--- | :--- | :--- | :--- |
-| 1 | 1 | Applicant Meets Qualifications | 70 |
-| 1 | 2 | Applicant Meets Qualifications | 85 |
-| 2 | 1 | Applicant Meets Qualifications | 85 |
-| 2 | 2 | Applicant Meets Qualifications | 100 |
-| 1 or 2 | 0 | Applicant Does Not Meet Qualifications |
-| 0 | N/A | Does Not Move Forward to Interview Two |
+{% include _results-key.md %}


### PR DESCRIPTION
…. [Fixes #83] Adds time in grade paragraph to certificate phase. [Fixes #80]

Stephanie - I ended up just merging the tables into one new table and then including that in each place that references a table. So now they are consistent. I didn't remove the toolkit items and put them onto the page. But we could create sub-pages rather than toolkit items, given that both toolkit items are just pages with this same key on it. 

The time-in-grade change is a little nerve-racking given that we have a large disclaimer right above it that reads:

> After SMEs identify the qualified applicants, do not conduct a separate minimum qualification review.

Want to get your triple check that you want to proceed there.