### PR TITLE
fix link to job analysis workshop agendas

### DIFF
--- a/pages/phases/job-analysis/index.html
+++ b/pages/phases/job-analysis/index.html
@@ -45,7 +45,7 @@ outputs:
 
 <p>Your job analysis workshop should be a total of 16 active hours, which typically spans 2.5 days with breaks. Send calendar invites to as many SMEs and hiring managers who will participate in your hiring action as possible.</p>
 <ul class="usa-list">
-  <li>Update the <a href="{{site.baseurl}}/toolkit/job-analysis/job-analysis-day-1-presentation/">Day 1</a> and <a href="{{site.baseurl}}/toolkit/job-analysis/job-analysis-day-2-presentation/">Day 2</a>presentations with your agency-specific information.</li>
+  <li>Update the <a href="{{site.baseurl}}/toolkit/job-analysis/job-analysis-day-1-presentation/">Day 1</a> and <a href="{{site.baseurl}}/toolkit/job-analysis/job-analysis-day-2-presentation/">Day 2</a> presentations with your agency-specific information.</li>
   <li>Update and print the <a href="{{site.baseurl}}/toolkit/job-analysis/agenda-for-job-analysis-workshop-day-1/">Day 1</a> and <a href="{{site.baseurl}}/toolkit/job-analysis/agenda-for-job-analysis-workshop-day-2/">Day 2</a> agendas as necessary for distribution at the workshop.</li>
   <li>Print the <a href="{{site.baseurl}}/toolkit/job-analysis/sample-competencies.docx">Sample Competencies</a> to distribute at the workshop as supporting material.</li>
 </ul>

--- a/toolkit/job-analysis/agenda-for-job-analysis-workshop-day-1.md
+++ b/toolkit/job-analysis/agenda-for-job-analysis-workshop-day-1.md
@@ -1,6 +1,6 @@
 ---
 layout: article
-permalink: /toolkit/job-analysis/workshop-agenda-day-1/
+permalink: /toolkit/job-analysis/agenda-for-job-analysis-workshop-day-1/
 section: hiring-phases
 sidenav: hiring-phases
 phase: job-analysis

--- a/toolkit/job-analysis/agenda-for-job-analysis-workshop-day-2.md
+++ b/toolkit/job-analysis/agenda-for-job-analysis-workshop-day-2.md
@@ -1,6 +1,6 @@
 ---
 layout: article
-permalink: /toolkit/job-analysis/workshop-agenda-day-2/
+permalink: /toolkit/job-analysis/agenda-for-job-analysis-workshop-day-2/
 section: hiring-phases
 sidenav: hiring-phases
 phase: job-analysis


### PR DESCRIPTION
fixing two links so their URL matches the site link and the .md filename. Also adds a missing space.