### PR TITLE
Unify agency name style in results menu

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -132,5 +132,5 @@ results:
     href: "/results/"
   - text: Health and Human Services
     href: "/results/hhs/"
-  - text: Department of Interior
+  - text: Interior
     href: "/results/doi/"


### PR DESCRIPTION
Small change so that we treat agency names the same in our menus. Ideally, we'd say "Department of Health and Human Services" and "Department of the Interior" but I get that those are a little long/wordy.