### PR TITLE
Change "round 1" and "round 2" to "initial" and "subsequent"

### DIFF
--- a/pages/results/index.html
+++ b/pages/results/index.html
@@ -12,7 +12,7 @@ sidenav: results
 {% assign round_two_agencies = site.data.results | where: "round", "2" | sort: "name" %}
 
 <p class="smeqa-brief-hiring-actions__brief">
-  U.S. Digital Service and OPM have conducted two rounds of pilots over the previous 20 months: 
+  The U.S. Digital Service and OPM conducted two rounds of pilots over the previous 20 months: 
 </p>
 {% include results/pilot-hiring-actions-summary.html %}
 
@@ -20,30 +20,30 @@ sidenav: results
 <div class="smeqa-results-rounds">
   <div class="smeqa-results-rounds__row">
     <div class="smeqa-results-round">
-      <h3 class="smeqa-results-round__title">Round One</h3>
+      <h3 class="smeqa-results-round__title">Initial Pilots (spring 2019)</h3>
       <h4 class="smeqa-results-round__sub-title">What we set out to accomplish</h4>
       <p>
         Agencies can drastically improve hiring outcomes using current delegated examining rules and regulations by incorporating Subject Matter Experts into the process.
       </p>
       <p>
-        Through the spring of 2019, the team tested the SME-QA process with 2 agencies and focused on improving the quality of applicants who appear on certificates. 
+        In spring 2019, the team tested the SME-QA process with two agencies, focusing on improving the quality of applicants appearing on certificates. Our <a href="https://smeqa.usds.gov/assets/SMEQA-initial-pilots-final-report.pdf">final report</a> and <a href="case study</a> review the results and lessons learned.
       </p>
       <p>
         <a href="{{ site.baseurl }}/results/round-one/" class="usa-button usa-button--outline smeqa-results-round__cta">Initial pilot results</a>
       </p>
     </div>
     <div class="smeqa-results-round">
-      <h3 class="smeqa-results-round__title">Round Two</h3>
+      <h3 class="smeqa-results-round__title">Subsequent pilots</h3>
       <h4 class="smeqa-results-round__sub-title">What we set out to accomplish</h4>
       <p>
-        These pilots were intended to discover if the SME-QA process could be more flexible to different assessment types and sped up through the use of better tools. This include the creation of a Resume Review Tool. 
+        Later pilots sought to discover if the SME-QA process could flex to different assessment types and sped up through better tools to make resume reviews and interviews easier to manage.
       </p>
       <p>
         Over the course of 2020, the team refined the process with pilots at 15 agencies, including a government-wide pilot. Additional pilots are currently underway.
       </p>
       <p>
         <a href="{{ site.baseurl }}/results/round-two/" class="usa-button usa-button--outline smeqa-results-round__cta">
-          Round 2 pilot results
+          Single agency pilot results
         </a>
         <a href="{{ site.baseurl }}/results/gov-wide/cx/" class="usa-button usa-button--outline smeqa-results-round__cta">
           Gov-wide pilot results


### PR DESCRIPTION
Unless we intend to declare a round 3, seems like we should change our nomenclature? Also adds links.