### PR TITLE
fix USDS branding in footer

### DIFF
--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -51,7 +51,7 @@
             <img class="usa-footer__logo-img chp-footer-secondary__logo" src="{{ site.baseurl }}/assets/img/usds-logo-footer.svg" alt="USDS logo">
           </div>
           <div class="mobile-lg:grid-col-auto">
-            <h3 class="usa-footer__logo-heading">U.S. Digital Service</h3>
+            <h2 class="usa-footer__logo-heading"></h2>
           </div>
         </div>
         <div class="usa-footer__contact-links mobile-lg:grid-col-6">


### PR DESCRIPTION
remove extra "USDS" text (redundant w/ logo), and try to standardize to match sprint.USDS.gov