### PR TITLE
Fix results grid alignment on the About page

### DIFF
--- a/_includes/results/pilot-hiring-actions-summary.html
+++ b/_includes/results/pilot-hiring-actions-summary.html
@@ -38,8 +38,8 @@
 {% endfor %}
 
 {% assign hired = 0 %}
-{% for hired in total_hired %}
-  {% assign hired = hired | plus: hired %}
+{% for accepted in total_hired %}
+  {% assign hired = hired | plus: accepted %}
 {% endfor %}
 
 {% assign applicants = 0 %}
@@ -69,6 +69,6 @@
     <span class="smeqa-brief-hiring-actions__stat">{{ selections }}</span> selections
   </li>
   <li class="smeqa-brief-hiring-actions__item">
-    <span class="smeqa-brief-hiring-actions__stat">221</span> accepted offers
+    <span class="smeqa-brief-hiring-actions__stat">{{ hired }}</span> accepted offers
   </li>
 </ul>

--- a/_scss/_uswds-theme-custom-styles.scss
+++ b/_scss/_uswds-theme-custom-styles.scss
@@ -664,11 +664,11 @@ blockquote {
   &__list {
     list-style-type: none;
     padding: 0;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
   }
 
   &__item {
-    display: inline-block;
-    width: 32%;
     margin: 0 0 units(2);
     padding: units(2);
     text-align: center;


### PR DESCRIPTION
Uses css grid on the results grid rather than percentages to set the size.

![fixed grid](https://user-images.githubusercontent.com/49658917/182933826-fb58df0f-27f5-40db-8920-07091d70d0b5.png)
