### PR TITLE
Add job links to results

### DIFF
--- a/_includes/results/pilot-by-the-numbers.html
+++ b/_includes/results/pilot-by-the-numbers.html
@@ -4,9 +4,15 @@
 
 <h5 class="smeqa-brief-hiring-action__position">
   {%- unless grades.size > 1 -%}
-    {{ pilot.role }} - {{ grades | join: ", " }} - {{ pilot.series }} series
+    <a class="usa-link" href="{{ pilot.joa.url }}" target="_blank">{{ pilot.role }}</a>
+    <span class="margin-x-05">-</span>
+    {{ grades | join: ", " }}
+    <span class="margin-x-05">-</span>
+    {{ pilot.series }} series
   {%- else -%}
-    {{ pilot.role }} - {{ pilot.series }} series
+    <a class="usa-link" href="{{ pilot.joa.url }}" target="_blank">{{ pilot.role }}</a>
+    <span class="margin-x-05">-</span>
+    {{ pilot.series }} series
   {%- endunless -%}
 </h5>
 

--- a/_scss/_uswds-theme-custom-styles.scss
+++ b/_scss/_uswds-theme-custom-styles.scss
@@ -698,7 +698,7 @@ blockquote {
   }
 
   &__position {
-    margin: units(0.5) 0;
+    margin: units(2) 0 units(1) 0;
   }
 
   &__stats-nested {


### PR DESCRIPTION
Resolves #412

This PR adds job links to the results page. Also does a minor style tweak for better spacing (in my opinion). Screenshot below:

![Results page with job links](https://user-images.githubusercontent.com/49658917/183701898-ecc47652-22e9-4f35-a135-c54d34a013ad.png)
