### PR TITLE
Fix breadcrumb list hierarchy

### DIFF
--- a/_includes/_breadcrumbs.html
+++ b/_includes/_breadcrumbs.html
@@ -10,7 +10,7 @@
   {% for crumb in crumbs offset: 1 %}
     {% assign position = position  | plus: 1 %}
     {% if forloop.last %}
-      / {{ page.title }}
+      <li class="chp-breadcrumb__item">/ {{ page.title }}</li>
     {% else %}
       <li class="chp-breadcrumb__item" property="itemListElement" typeof="ListItem">
       / <a class="chp-breadcrumb__link" property="item" typeof="WebPage" href="{{ site.baseurl }}{% assign crumb_limit = forloop.index | plus: 1 %}{% for crumb in crumbs limit: crumb_limit %}{{ crumb | append: '/' | replace:'without-plugin/','without-plugins/' }}{% endfor %}">


### PR DESCRIPTION
Fixes #371

While the bug report points to the `<meta />` tag inside breadcrumb list items, this is actually a valid way to specify RDFa metadata ([see USWDS reference here](https://designsystem.digital.gov/components/breadcrumb/)).

The issue does, however, capture an actual issue with the breadcrumb list: the final item is not wrapped in an `<li />` tag. This PR wraps that final list item in the correct tag and an a11y audit verifies this fix.